### PR TITLE
Fix Publish Script

### DIFF
--- a/.github/workflows/backend-publish.yml
+++ b/.github/workflows/backend-publish.yml
@@ -38,7 +38,7 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.HOST_PROD }}
-          username: ubuntu
+          username: ec2-user
           key: ${{ secrets.PRIVATE_KEY }}
           envs: GITHUB_SHA
           script: |


### PR DESCRIPTION
## 📎 관련 Issue 번호
closes #18 

## 📄 작업 내용 요약
ec2 인스턴스가 ubuntu가 아닌 amazon linux 임에 따라 
SSH username ubuntu → ec2-user 로 배포 스크립트 수정했습니다.

## 🙋🏻 주의 깊게 확인해야 하는 코드
```
name: Deploy to prod
uses: appleboy/ssh-action@master
with:
    host: ${{ secrets.HOST_PROD }}
    username: ec2-user ## 이 부분 수정
```

## 📄 개선 사항 OR 참고 사항
예외 상황으로 hotfix → main → develop 브랜치 최신화 진행해야 할 것 같습니다.