### PR TITLE
Add Local Image Lookup Function

### DIFF
--- a/src/main/java/com/dnd/spaced/domain/image/application/LocalImageService.java
+++ b/src/main/java/com/dnd/spaced/domain/image/application/LocalImageService.java
@@ -1,0 +1,21 @@
+package com.dnd.spaced.domain.image.application;
+
+import com.dnd.spaced.global.config.properties.ImageStorePathProperties;
+import java.net.MalformedURLException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LocalImageService {
+
+    private static final String FILE_PROTOCOL_PREFIX = "file:";
+
+    private final ImageStorePathProperties imageStorePathProperties;
+
+    public Resource readImage(String name) throws MalformedURLException {
+        return new UrlResource(FILE_PROTOCOL_PREFIX + imageStorePathProperties.path() + name);
+    }
+}

--- a/src/main/java/com/dnd/spaced/domain/image/presentation/LocalImageController.java
+++ b/src/main/java/com/dnd/spaced/domain/image/presentation/LocalImageController.java
@@ -1,0 +1,33 @@
+package com.dnd.spaced.domain.image.presentation;
+
+import com.dnd.spaced.domain.image.application.LocalImageService;
+import java.net.MalformedURLException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/images")
+@RequiredArgsConstructor
+public class LocalImageController {
+
+    private final LocalImageService localImageService;
+
+    @GetMapping("/{name}")
+    public ResponseEntity<Resource> readImage(@PathVariable String name) throws MalformedURLException {
+        Resource resource = localImageService.readImage(name);
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.setContentType(MediaType.IMAGE_PNG);
+
+        return ResponseEntity.ok()
+                             .headers(headers)
+                             .body(resource);
+    }
+}

--- a/src/main/java/com/dnd/spaced/global/config/AppConfig.java
+++ b/src/main/java/com/dnd/spaced/global/config/AppConfig.java
@@ -1,5 +1,6 @@
 package com.dnd.spaced.global.config;
 
+import com.dnd.spaced.global.config.properties.ImageStorePathProperties;
 import com.dnd.spaced.global.config.properties.UrlProperties;
 import com.dnd.spaced.global.interceptor.AuthInterceptor;
 import com.dnd.spaced.global.resolver.auth.AuthAccountInfoArgumentResolver;
@@ -20,7 +21,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
-@EnableConfigurationProperties(UrlProperties.class)
+@EnableConfigurationProperties(value = {UrlProperties.class, ImageStorePathProperties.class})
 public class AppConfig implements WebMvcConfigurer {
 
     private static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";

--- a/src/main/java/com/dnd/spaced/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/spaced/global/config/SecurityConfig.java
@@ -76,6 +76,7 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.POST, "/refresh-token").permitAll()
                     .requestMatchers(HttpMethod.GET, "/comments/popular").permitAll()
                     .requestMatchers(HttpMethod.GET, "/words/{wordId}/comments").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/images/{name}").permitAll()
                     .anyRequest().authenticated()
             )
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))

--- a/src/main/java/com/dnd/spaced/global/config/properties/ImageStorePathProperties.java
+++ b/src/main/java/com/dnd/spaced/global/config/properties/ImageStorePathProperties.java
@@ -1,0 +1,7 @@
+package com.dnd.spaced.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("app.image")
+public record ImageStorePathProperties(String path) {
+}

--- a/src/main/java/com/dnd/spaced/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/dnd/spaced/global/exception/GlobalControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.dnd.spaced.global.exception;
 
 import com.dnd.spaced.global.exception.dto.ExceptionDto;
+import java.net.MalformedURLException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -38,6 +39,16 @@ public class GlobalControllerAdvice extends ResponseEntityExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                              .body(translator.translate());
+    }
+
+    @ExceptionHandler(MalformedURLException.class)
+    private ResponseEntity<ExceptionDto> handleMalformedURLException(MalformedURLException ex) {
+        logger.warn(String.format(LOG_FORMAT, ex.getClass().getSimpleName()), ex);
+
+        ExceptionDto exceptionDto = new ExceptionDto("IMAGE_ERROR", "이미지 조회 과정 중 문제가 발생했습니다.");
+
+        return ResponseEntity.badRequest()
+                             .body(exceptionDto);
     }
 
     @Override

--- a/src/main/java/com/dnd/spaced/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/dnd/spaced/global/interceptor/AuthInterceptor.java
@@ -28,7 +28,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         Authentication authentication = SecurityContextHolder.getContext()
                                                              .getAuthentication();
 
-        if (authentication instanceof AnonymousAuthenticationToken) {
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
             store.set(new AuthAccountInfo(null));
             return true;
         }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -29,6 +29,8 @@ app:
   url:
     base-url: http://localhost:8080/
     image-uri: images/
+  image:
+    path: /home/
   profile:
     nickname:
       adjective:


### PR DESCRIPTION
## 📎 관련 Issue 번호
<!-- (필수) 해당 PR과 관련 있는 issue 번호를 입력해주세요. -->
- closed #33 
## 📄 작업 내용 요약
<!-- (필수) 작업한 내용을 간단히 요약해주세요. -->
로컬 이미지 조회 기능 추가 
## 🙋🏻 주의 깊게 확인해야 하는 코드

### MalformedURLException 관련 예외 핸들링
MalformedURLException는 다음과 같은 상황에서 발생합니다 

- 잘못된 URL 형식
- 지원되지 않는 프로토콜
- 상대 경로 문제(지정한 경로에 이미지가 없는 경우나 상대 경로를 변환하는 도중 문제가 발생하는 경우 등등)
- 인코딩 

이 예외가 발생하는 경우는 대부분 지정한 경로에 이미지가 없는 경우기는 하지만, 다른 상황에서도 예외가 발생할 수 있기 때문에 예외를 별도의 커스텀 예외로 변환하기보다는 해당 예외를 그대로 유지하면서 로그를 남기는 것이 더 모니터링 시 명확하다고 판단했습니다 

그래서 해당 예외를 Base 예외로 변환하지 않고 그대로 던지도록 설정했고 GlobalControllerAdvice에서 MalformedURLException를 핸들링하도록 처리했습니다

## 📄 개선 사항 OR 참고 사항
<!-- (선택) 해당 PR에서 개선했거나, 참고 사항이 있다면 설명해주세요. -->
- 현재 프로필 이미지를 업로드 기능 없이, 미리 만들어놓은 프로필 이미지 중 랜덤하게 하나를 지정해주기로 한 상황이므로 로컬에서 조회하는 기능만 추가했습니다 
- 추후 프로필 이미지를 변경할 수 있고, 이렇게 변경한 이미지를 서버에서 관리한다면 LocalImageController에서 이미지를 저장하는 로직을 추가하면 될 것 같습니다 
- 만약 프로필 이미지를 변경할 수 있고, 외부 저장소(S3와 같은)에서 이미지를 관리한다면 LocalImageController가 아닌 별도의 이미지 컨트롤러를 새롭게 추가하면 될 것 같습니다 