### PR TITLE
Fix Publish Script

### DIFF
--- a/.github/workflows/backend-publish.yml
+++ b/.github/workflows/backend-publish.yml
@@ -46,4 +46,5 @@ jobs:
             sudo docker rm spaced
             sudo docker rmi ${{ secrets.DOCKER_USERNAME }}/spaced:0.0.1-SNAPSHOT
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/spaced:0.0.1-SNAPSHOT
-            sudo docker run -d -p 8080:8080 --name spaced ${{ secrets.DOCKER_USERNAME }}/spaced:0.0.1-SNAPSHOT
+            sudo docker run -d -p 8080:8080 --name spaced ${{ secrets.DOCKER_USERNAME }}/spaced:0.0.1-SNAPSHOT \
+              --spring.profiles.active=prod


### PR DESCRIPTION
## 📎 관련 Issue 번호
closes #42

## 📄 작업 내용 요약
CD 파이프라인에 `spring.profiles.active=prod` 옵션 추가했습니다

## 🙋🏻 주의 깊게 확인해야 하는 코드
```shell
script: |
            sudo docker stop spaced
            sudo docker rm spaced
            sudo docker rmi ${{ secrets.DOCKER_USERNAME }}/spaced:0.0.1-SNAPSHOT
            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/spaced:0.0.1-SNAPSHOT
            sudo docker run -d -p 8080:8080 --name spaced ${{ secrets.DOCKER_USERNAME }}/spaced:0.0.1-SNAPSHOT \
              --spring.profiles.active=prod ## 이부분
```

## 📄 개선 사항 OR 참고 사항
브랜치 최신화 진행하겠습니다