### PR TITLE
Fix /popular and /{wordId}/comments token error

### DIFF
--- a/src/main/java/com/dnd/spaced/domain/comment/application/CommentService.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/application/CommentService.java
@@ -113,14 +113,31 @@ public class CommentService {
     }
 
     public List<MultipleCommentInfoDto> findAllBy(CommentConditionInfoDto dto) {
-        CommentConditionDto commentConditionDto = CommentRepositoryMapper.to(
-                dto.wordId(),
-                findAccountId(dto.email()),
-                dto.lastCommentId(),
-                dto.lastLikeCount(),
-                dto.pageable()
-        );
-        List<CommentInfoWithLikeDto> result = commentRepository.findAllBy(commentConditionDto);
+        List<CommentInfoWithLikeDto> result;
+
+        if (dto.email() != null) {
+            CommentConditionDto commentConditionDto = CommentRepositoryMapper.to(
+                    dto.wordId(),
+                    findAccountId(dto.email()),
+                    dto.lastCommentId(),
+                    dto.lastLikeCount(),
+                    dto.pageable()
+            );
+
+            result = commentRepository.findAllBy(commentConditionDto);
+        } else {
+            CommentConditionDto commentConditionDto = CommentRepositoryMapper.to(
+                    dto.wordId(),
+                    null,
+                    dto.lastCommentId(),
+                    dto.lastLikeCount(),
+                    dto.pageable()
+            );
+
+            result = CommentServiceMapper.toNonMemberCommentList(
+                    commentRepository.findAllBy(commentConditionDto)
+            );
+        }
 
         return CommentServiceMapper.fromComment(result);
     }

--- a/src/main/java/com/dnd/spaced/domain/comment/application/CommentService.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/application/CommentService.java
@@ -159,14 +159,14 @@ public class CommentService {
         return CommentServiceMapper.ofWritten(result, account);
     }
 
-    public List<MultiplePopularCommentInfoDto> findPopularAllForMember(Pageable pageable, String email) {
+    private List<MultiplePopularCommentInfoDto> findPopularAllForMember(Pageable pageable, String email) {
         Long accountId = findAccountId(email);
         List<PopularCommentInfoDto> result = commentRepository.findPopularAllBy(pageable, accountId);
 
         return CommentServiceMapper.fromPopularComment(result);
     }
 
-    public List<MultiplePopularCommentInfoDto> findPopularAllForNonMember(Pageable pageable) {
+    private List<MultiplePopularCommentInfoDto> findPopularAllForNonMember(Pageable pageable) {
         List<PopularCommentWithoutIsLikeDto> result = commentRepository.findPopularAll(pageable);
 
         return CommentServiceMapper.fromPopularCommentWithOutIsLike(result);

--- a/src/main/java/com/dnd/spaced/domain/comment/application/CommentService.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/application/CommentService.java
@@ -26,6 +26,7 @@ import com.dnd.spaced.domain.comment.domain.repository.dto.CommentRepositoryMapp
 import com.dnd.spaced.domain.comment.domain.repository.dto.request.CommentConditionDto;
 import com.dnd.spaced.domain.comment.domain.repository.dto.response.CommentInfoWithLikeDto;
 import com.dnd.spaced.domain.comment.domain.repository.dto.response.PopularCommentInfoDto;
+import com.dnd.spaced.domain.comment.domain.repository.dto.response.PopularCommentWithoutIsLikeDto;
 import com.dnd.spaced.domain.word.domain.Word;
 import com.dnd.spaced.domain.word.domain.repository.WordRepository;
 import java.util.List;
@@ -125,10 +126,16 @@ public class CommentService {
     }
 
     public List<MultiplePopularCommentInfoDto> findPopularAllBy(Pageable pageable, String email) {
-        Long accountId = findAccountId(email);
-        List<PopularCommentInfoDto> result = commentRepository.findPopularAllBy(pageable, accountId);
+        if (email != null) {
+            Long accountId = findAccountId(email);
+            List<PopularCommentInfoDto> result = commentRepository.findPopularAllBy(pageable, accountId);
 
-        return CommentServiceMapper.fromPopularComment(result);
+            return CommentServiceMapper.fromPopularComment(result);
+        } else {
+            List<PopularCommentWithoutIsLikeDto> result = commentRepository.findPopularAll(pageable);
+
+            return CommentServiceMapper.fromPopularCommentWithOutIsLike(result);
+        }
     }
 
     public List<LikedCommentDto> findAllByLiked(ReadCommentAllByLikedDto dto) {

--- a/src/main/java/com/dnd/spaced/domain/comment/application/CommentService.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/application/CommentService.java
@@ -127,14 +127,9 @@ public class CommentService {
 
     public List<MultiplePopularCommentInfoDto> findPopularAllBy(Pageable pageable, String email) {
         if (email != null) {
-            Long accountId = findAccountId(email);
-            List<PopularCommentInfoDto> result = commentRepository.findPopularAllBy(pageable, accountId);
-
-            return CommentServiceMapper.fromPopularComment(result);
+            return findPopularAllForMember(pageable, email);
         } else {
-            List<PopularCommentWithoutIsLikeDto> result = commentRepository.findPopularAll(pageable);
-
-            return CommentServiceMapper.fromPopularCommentWithOutIsLike(result);
+            return findPopularAllForNonMember(pageable);
         }
     }
 
@@ -162,6 +157,19 @@ public class CommentService {
         );
 
         return CommentServiceMapper.ofWritten(result, account);
+    }
+
+    public List<MultiplePopularCommentInfoDto> findPopularAllForMember(Pageable pageable, String email) {
+        Long accountId = findAccountId(email);
+        List<PopularCommentInfoDto> result = commentRepository.findPopularAllBy(pageable, accountId);
+
+        return CommentServiceMapper.fromPopularComment(result);
+    }
+
+    public List<MultiplePopularCommentInfoDto> findPopularAllForNonMember(Pageable pageable) {
+        List<PopularCommentWithoutIsLikeDto> result = commentRepository.findPopularAll(pageable);
+
+        return CommentServiceMapper.fromPopularCommentWithOutIsLike(result);
     }
 
     private Long findAccountId(String email) {

--- a/src/main/java/com/dnd/spaced/domain/comment/application/CommentService.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/application/CommentService.java
@@ -113,33 +113,11 @@ public class CommentService {
     }
 
     public List<MultipleCommentInfoDto> findAllBy(CommentConditionInfoDto dto) {
-        List<CommentInfoWithLikeDto> result;
-
         if (dto.email() != null) {
-            CommentConditionDto commentConditionDto = CommentRepositoryMapper.to(
-                    dto.wordId(),
-                    findAccountId(dto.email()),
-                    dto.lastCommentId(),
-                    dto.lastLikeCount(),
-                    dto.pageable()
-            );
-
-            result = commentRepository.findAllBy(commentConditionDto);
+            return findMemberComments(dto);
         } else {
-            CommentConditionDto commentConditionDto = CommentRepositoryMapper.to(
-                    dto.wordId(),
-                    null,
-                    dto.lastCommentId(),
-                    dto.lastLikeCount(),
-                    dto.pageable()
-            );
-
-            result = CommentServiceMapper.toNonMemberCommentList(
-                    commentRepository.findAllBy(commentConditionDto)
-            );
+            return findNonMemberComments(dto);
         }
-
-        return CommentServiceMapper.fromComment(result);
     }
 
     public List<MultiplePopularCommentInfoDto> findPopularAllBy(Pageable pageable, String email) {
@@ -187,6 +165,48 @@ public class CommentService {
         List<PopularCommentWithoutIsLikeDto> result = commentRepository.findPopularAll(pageable);
 
         return CommentServiceMapper.fromPopularCommentWithOutIsLike(result);
+    }
+
+    private List<MultipleCommentInfoDto> findMemberComments(CommentConditionInfoDto dto) {
+        CommentConditionDto commentConditionDto = createCommentConditionDto(
+                dto.wordId(),
+                findAccountId(dto.email()),
+                dto.lastCommentId(),
+                dto.lastLikeCount(),
+                dto.pageable()
+        );
+
+        List<CommentInfoWithLikeDto> result = commentRepository.findAllBy(commentConditionDto);
+        return CommentServiceMapper.fromComment(result);
+    }
+
+    private List<MultipleCommentInfoDto> findNonMemberComments(CommentConditionInfoDto dto) {
+        CommentConditionDto commentConditionDto = createCommentConditionDto(
+                dto.wordId(),
+                null,
+                dto.lastCommentId(),
+                dto.lastLikeCount(),
+                dto.pageable()
+        );
+
+        List<CommentInfoWithLikeDto> result = commentRepository.findAllBy(commentConditionDto);
+        List<CommentInfoWithLikeDto> nonMemberComments = CommentServiceMapper.toNonMemberCommentList(result);
+        return CommentServiceMapper.fromComment(nonMemberComments);
+    }
+
+    private CommentConditionDto createCommentConditionDto(
+            Long wordId,
+            Long accountId,
+            Long lastCommentId,
+            Integer lastLikeCount,
+            Pageable pageable) {
+        return CommentRepositoryMapper.to(
+                wordId,
+                accountId,
+                lastCommentId,
+                lastLikeCount,
+                pageable
+        );
     }
 
     private Long findAccountId(String email) {

--- a/src/main/java/com/dnd/spaced/domain/comment/application/CommentService.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/application/CommentService.java
@@ -168,7 +168,7 @@ public class CommentService {
     }
 
     private List<MultipleCommentInfoDto> findMemberComments(CommentConditionInfoDto dto) {
-        CommentConditionDto commentConditionDto = createCommentConditionDto(
+        CommentConditionDto commentConditionDto = CommentRepositoryMapper.toCommentConditionDto(
                 dto.wordId(),
                 findAccountId(dto.email()),
                 dto.lastCommentId(),
@@ -181,7 +181,7 @@ public class CommentService {
     }
 
     private List<MultipleCommentInfoDto> findNonMemberComments(CommentConditionInfoDto dto) {
-        CommentConditionDto commentConditionDto = createCommentConditionDto(
+        CommentConditionDto commentConditionDto = CommentRepositoryMapper.toCommentConditionDto(
                 dto.wordId(),
                 null,
                 dto.lastCommentId(),
@@ -192,21 +192,6 @@ public class CommentService {
         List<CommentInfoWithLikeDto> result = commentRepository.findAllBy(commentConditionDto);
         List<CommentInfoWithLikeDto> nonMemberComments = CommentServiceMapper.toNonMemberCommentList(result);
         return CommentServiceMapper.fromComment(nonMemberComments);
-    }
-
-    private CommentConditionDto createCommentConditionDto(
-            Long wordId,
-            Long accountId,
-            Long lastCommentId,
-            Integer lastLikeCount,
-            Pageable pageable) {
-        return CommentRepositoryMapper.to(
-                wordId,
-                accountId,
-                lastCommentId,
-                lastLikeCount,
-                pageable
-        );
     }
 
     private Long findAccountId(String email) {

--- a/src/main/java/com/dnd/spaced/domain/comment/application/dto/CommentServiceMapper.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/application/dto/CommentServiceMapper.java
@@ -16,6 +16,7 @@ import com.dnd.spaced.domain.comment.domain.repository.dto.request.FindCommentAl
 import com.dnd.spaced.domain.comment.domain.repository.dto.request.FindCommentAllByWrittenConditionDto;
 import com.dnd.spaced.domain.comment.domain.repository.dto.response.CommentInfoWithLikeDto;
 import com.dnd.spaced.domain.comment.domain.repository.dto.response.PopularCommentInfoDto;
+import com.dnd.spaced.domain.comment.domain.repository.dto.response.PopularCommentWithoutIsLikeDto;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -56,6 +57,12 @@ public final class CommentServiceMapper {
         return dtos.stream()
                    .map(MultiplePopularCommentInfoDto::from)
                    .toList();
+    }
+
+    public static List<MultiplePopularCommentInfoDto> fromPopularCommentWithOutIsLike(List<PopularCommentWithoutIsLikeDto> dtos) {
+        return dtos.stream()
+                .map(MultiplePopularCommentInfoDto::from)
+                .toList();
     }
 
     public static FindCommentAllByLikedConditionDto ofLiked(Long accountId, Long lastCommentId, Pageable pageable) {

--- a/src/main/java/com/dnd/spaced/domain/comment/application/dto/CommentServiceMapper.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/application/dto/CommentServiceMapper.java
@@ -92,4 +92,23 @@ public final class CommentServiceMapper {
     public static ReadCommentAllByWrittenDto ofWritten(String email, Long lastCommentId, Pageable pageable) {
         return new ReadCommentAllByWrittenDto(email, lastCommentId, pageable);
     }
+
+    public static List<CommentInfoWithLikeDto> toNonMemberCommentList(List<CommentInfoWithLikeDto> comments) {
+        return comments.stream()
+                .map(comment -> new CommentInfoWithLikeDto(
+                        comment.commentId(),
+                        comment.writerId(),
+                        comment.wordId(),
+                        comment.content(),
+                        comment.likeCount(),
+                        comment.createdAt(),
+                        comment.updatedAt(),
+                        comment.writerNickname(),
+                        comment.writerProfileImage(),
+                        comment.likeAccountId(),
+                        false
+                ))
+                .toList();
+    }
+
 }

--- a/src/main/java/com/dnd/spaced/domain/comment/application/dto/response/MultiplePopularCommentInfoDto.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/application/dto/response/MultiplePopularCommentInfoDto.java
@@ -1,6 +1,7 @@
 package com.dnd.spaced.domain.comment.application.dto.response;
 
 import com.dnd.spaced.domain.comment.domain.repository.dto.response.PopularCommentInfoDto;
+import com.dnd.spaced.domain.comment.domain.repository.dto.response.PopularCommentWithoutIsLikeDto;
 import java.time.LocalDateTime;
 
 public record MultiplePopularCommentInfoDto(
@@ -26,6 +27,21 @@ public record MultiplePopularCommentInfoDto(
                 dto.likeAccountId() != null
         );
     }
+
+    public static MultiplePopularCommentInfoDto from(PopularCommentWithoutIsLikeDto dto) {
+        PronunciationInfoDto pronunciationInfo = new PronunciationInfoDto(dto.pronunciation().getEnglish());
+
+        return new MultiplePopularCommentInfoDto(
+                dto.commentId(),
+                new WordInfoDto(dto.wordId(), dto.wordName(), dto.wordCategory().getName(), pronunciationInfo),
+                dto.content(),
+                dto.likeCount(),
+                dto.createdAt(),
+                dto.updatedAt(),
+                false
+        );
+    }
+
 
     public record WordInfoDto(Long id, String name, String categoryName, PronunciationInfoDto pronunciationInfo) {
     }

--- a/src/main/java/com/dnd/spaced/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/domain/repository/CommentRepository.java
@@ -6,6 +6,7 @@ import com.dnd.spaced.domain.comment.domain.repository.dto.request.FindCommentAl
 import com.dnd.spaced.domain.comment.domain.repository.dto.request.FindCommentAllByWrittenConditionDto;
 import com.dnd.spaced.domain.comment.domain.repository.dto.response.CommentInfoWithLikeDto;
 import com.dnd.spaced.domain.comment.domain.repository.dto.response.PopularCommentInfoDto;
+import com.dnd.spaced.domain.comment.domain.repository.dto.response.PopularCommentWithoutIsLikeDto;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +22,8 @@ public interface CommentRepository {
     List<CommentInfoWithLikeDto> findAllBy(CommentConditionDto dto);
 
     List<PopularCommentInfoDto> findPopularAllBy(Pageable pageable, Long accountId);
+
+    List<PopularCommentWithoutIsLikeDto> findPopularAll(Pageable pageable);
 
     boolean existsBy(Long commentId);
 

--- a/src/main/java/com/dnd/spaced/domain/comment/domain/repository/QuerydslCommentRepository.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/domain/repository/QuerydslCommentRepository.java
@@ -11,6 +11,7 @@ import com.dnd.spaced.domain.comment.domain.repository.dto.request.FindCommentAl
 import com.dnd.spaced.domain.comment.domain.repository.dto.request.FindCommentAllByWrittenConditionDto;
 import com.dnd.spaced.domain.comment.domain.repository.dto.response.CommentInfoWithLikeDto;
 import com.dnd.spaced.domain.comment.domain.repository.dto.response.PopularCommentInfoDto;
+import com.dnd.spaced.domain.comment.domain.repository.dto.response.PopularCommentWithoutIsLikeDto;
 import com.dnd.spaced.domain.comment.domain.repository.util.CommentSortConditionConverter;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -104,6 +105,34 @@ public class QuerydslCommentRepository implements CommentRepository {
                            )
                            .limit(pageable.getPageSize())
                            .fetch();
+    }
+
+    @Override
+    public List<PopularCommentWithoutIsLikeDto> findPopularAll(Pageable pageable) {
+        return queryFactory.select(
+                        Projections.constructor(
+                                PopularCommentWithoutIsLikeDto.class,
+                                comment.id,
+                                word.id,
+                                word.name,
+                                word.category,
+                                word.pronunciation,
+                                comment.content,
+                                comment.likeCount,
+                                comment.createdAt,
+                                comment.updatedAt,
+                                like.id
+                        )
+                )
+                .from(comment)
+                .join(word).on(comment.wordId.eq(word.id))
+                .leftJoin(like).on(comment.id.eq(like.commentId))
+                .orderBy(
+                        CommentSortConditionConverter.convert(findOrder(pageable))
+                                .toArray(OrderSpecifier[]::new)
+                )
+                .limit(pageable.getPageSize())
+                .fetch();
     }
 
     @Override

--- a/src/main/java/com/dnd/spaced/domain/comment/domain/repository/QuerydslCommentRepository.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/domain/repository/QuerydslCommentRepository.java
@@ -52,30 +52,32 @@ public class QuerydslCommentRepository implements CommentRepository {
     @Override
     public List<CommentInfoWithLikeDto> findAllBy(CommentConditionDto dto) {
         return queryFactory.select(
-                                   Projections.constructor(
-                                           CommentInfoWithLikeDto.class,
-                                           comment.id,
-                                           comment.accountId,
-                                           comment.wordId,
-                                           comment.content,
-                                           comment.likeCount,
-                                           comment.createdAt,
-                                           comment.updatedAt,
-                                           account.nickname,
-                                           account.profileImage,
-                                           like.id
-                                   )
-                           )
-                           .from(comment)
-                           .join(account).on(comment.accountId.eq(account.id))
-                           .leftJoin(like).on(comment.id.eq(like.commentId), like.accountId.eq(dto.accountId()))
-                           .where(calculateFindAllBooleanExpression(dto), comment.wordId.eq(dto.wordId()))
-                           .orderBy(
-                                   CommentSortConditionConverter.convert(findOrder(dto.pageable()))
-                                                                .toArray(OrderSpecifier[]::new)
-                           )
-                           .limit(dto.pageable().getPageSize())
-                           .fetch();
+                        Projections.constructor(
+                                CommentInfoWithLikeDto.class,
+                                comment.id,
+                                comment.accountId,
+                                comment.wordId,
+                                comment.content,
+                                comment.likeCount,
+                                comment.createdAt,
+                                comment.updatedAt,
+                                account.nickname,
+                                account.profileImage,
+                                like.id,
+                                like.id.isNotNull()
+                        )
+                )
+                .from(comment)
+                .join(account).on(comment.accountId.eq(account.id))
+                .leftJoin(like).on(comment.id.eq(like.commentId),
+                        dto.accountId() != null ? like.accountId.eq(dto.accountId()) : like.accountId.isNull())
+                .where(calculateFindAllBooleanExpression(dto), comment.wordId.eq(dto.wordId()))
+                .orderBy(
+                        CommentSortConditionConverter.convert(findOrder(dto.pageable()))
+                                .toArray(OrderSpecifier[]::new)
+                )
+                .limit(dto.pageable().getPageSize())
+                .fetch();
     }
 
     @Override

--- a/src/main/java/com/dnd/spaced/domain/comment/domain/repository/dto/CommentRepositoryMapper.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/domain/repository/dto/CommentRepositoryMapper.java
@@ -17,4 +17,13 @@ public final class CommentRepositoryMapper {
     ) {
         return new CommentConditionDto(wordId, accountId, lastCommentId, lastLikeCount, pageable);
     }
+
+    public static CommentConditionDto toCommentConditionDto(
+            Long wordId,
+            Long accountId,
+            Long lastCommentId,
+            Integer lastLikeCount,
+            Pageable pageable) {
+        return new CommentConditionDto(wordId, accountId, lastCommentId, lastLikeCount, pageable);
+    }
 }

--- a/src/main/java/com/dnd/spaced/domain/comment/domain/repository/dto/response/CommentInfoWithLikeDto.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/domain/repository/dto/response/CommentInfoWithLikeDto.java
@@ -12,6 +12,7 @@ public record CommentInfoWithLikeDto(
         LocalDateTime updatedAt,
         String writerNickname,
         String writerProfileImage,
-        Long likeAccountId
+        Long likeAccountId,
+        boolean isLike
 ) {
 }

--- a/src/main/java/com/dnd/spaced/domain/comment/domain/repository/dto/response/PopularCommentWithoutIsLikeDto.java
+++ b/src/main/java/com/dnd/spaced/domain/comment/domain/repository/dto/response/PopularCommentWithoutIsLikeDto.java
@@ -1,0 +1,20 @@
+package com.dnd.spaced.domain.comment.domain.repository.dto.response;
+
+import com.dnd.spaced.domain.word.domain.Category;
+import com.dnd.spaced.domain.word.domain.Pronunciation;
+
+import java.time.LocalDateTime;
+
+public record PopularCommentWithoutIsLikeDto (
+        Long commentId,
+        Long wordId,
+        String wordName,
+        Category wordCategory,
+        Pronunciation pronunciation,
+        String content,
+        int likeCount,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        Long likeAccountId
+) {
+}


### PR DESCRIPTION
## 📎 관련 Issue 번호
- closes #135 

## 📄 작업 내용 요약
지금 반응이 뜨거운 댓글 목록 및 용어 상세 페이지 내 댓글 목록 조회 시 토큰 보내줘야만 작동 하는 에러
서비스 로직 메서드를 분리하여 비회원일 경우 토큰 없이도 정상 동작 하도록 수정 했습니다.

## 🙋🏻 주의 깊게 확인해야 하는 코드
x

## 📄 개선 사항 OR 참고 사항
x