### PR TITLE
Add querying the number of quiz participants api

### DIFF
--- a/src/main/java/com/dnd/spaced/domain/quiz/application/QuizService.java
+++ b/src/main/java/com/dnd/spaced/domain/quiz/application/QuizService.java
@@ -47,6 +47,10 @@ public class QuizService {
         return QuizServiceMapper.toResponse(quiz.getId(), quiz.getQuestions());
     }
 
+    public long getParticipantsCountToday() {
+        return quizResultRepository.countParticipantsToday();
+    }
+
     @Transactional
     public List<QuizResult> submitAnswers(Long quizId, QuizRequestDto requestDto) {
         List<QuizQuestion> questions = findQuizById(quizId).getQuestions();

--- a/src/main/java/com/dnd/spaced/domain/quiz/domain/QuizResult.java
+++ b/src/main/java/com/dnd/spaced/domain/quiz/domain/QuizResult.java
@@ -8,6 +8,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.*;
 
+import java.time.LocalDate;
+
 @Entity
 @Getter
 @EqualsAndHashCode(of = "id")
@@ -16,6 +18,8 @@ public class QuizResult {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private Long accountId;
 
     @ManyToOne
     @JoinColumn(name = "quiz_question_id")
@@ -27,14 +31,20 @@ public class QuizResult {
 
     private boolean isCorrect;
 
+    private LocalDate createdAt;
+
     @Builder
     private QuizResult(
             QuizQuestion quizQuestion,
             QuizOption selectedOption,
-            boolean isCorrect
+            boolean isCorrect,
+            Long accountId,
+            LocalDate createdAt
     ) {
         this.quizQuestion = quizQuestion;
         this.selectedOption = selectedOption;
         this.isCorrect = isCorrect;
+        this.accountId = accountId;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/dnd/spaced/domain/quiz/domain/repository/QuizResultRepository.java
+++ b/src/main/java/com/dnd/spaced/domain/quiz/domain/repository/QuizResultRepository.java
@@ -2,9 +2,12 @@ package com.dnd.spaced.domain.quiz.domain.repository;
 
 import com.dnd.spaced.domain.quiz.domain.QuizResult;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface QuizResultRepository extends CrudRepository<QuizResult, Long> {
+    @Query("SELECT COUNT(DISTINCT qr.accountId) FROM QuizResult qr WHERE DATE(qr.createdAt) = CURRENT_DATE")
+    long countParticipantsToday();
 }

--- a/src/main/java/com/dnd/spaced/domain/quiz/presentation/QuizController.java
+++ b/src/main/java/com/dnd/spaced/domain/quiz/presentation/QuizController.java
@@ -47,4 +47,10 @@ public class QuizController implements SwaggerQuizController{
         List<QuizResult> results = quizService.submitAnswers(id, requestDto);
         return ResponseEntity.ok(results);
     }
+
+    @GetMapping("/today/participants")
+    public ResponseEntity<Long> getParticipantsCountToday() {
+        long participantsCount = quizService.getParticipantsCountToday();
+        return ResponseEntity.ok(participantsCount);
+    }
 }


### PR DESCRIPTION
## 📎 관련 Issue 번호
- closes #154 

## 📄 작업 내용 요약
퀴즈 참여인원 조회 API 임시 개발

## 🙋🏻 주의 깊게 확인해야 하는 코드
x

## 📄 개선 사항 OR 참고 사항
현재 퀴즈 로직이 불안정하여, 해당 쿼리 또한 불안정한 상태이지만, 프론트와의 빠른 연결을 위해 배포를 먼저 진행할 예정입니다. 
이후 퀴즈 로직 리팩토링 #159 이 완료 되면, 퀴즈 참여인원 조회 쿼리도 회원과 비회원 구분하여 카운팅되도록 수정할 예정입니다.