### PR TITLE
Fix popular words API response by view count-based retrieval

### DIFF
--- a/src/main/java/com/dnd/spaced/domain/word/application/WordService.java
+++ b/src/main/java/com/dnd/spaced/domain/word/application/WordService.java
@@ -94,7 +94,7 @@ public class WordService {
     }
 
     public List<PopularWordInfoDto> findPopularAll(Pageable pageable) {
-        List<Word> result = popularWordRepository.findAllBy(LocalDateTime.now(clock), pageable);
+        List<Word> result = popularWordRepository.findByViewCount(pageable);
 
         return WordServiceMapper.from(result);
     }

--- a/src/main/java/com/dnd/spaced/domain/word/domain/repository/PopularWordRepository.java
+++ b/src/main/java/com/dnd/spaced/domain/word/domain/repository/PopularWordRepository.java
@@ -16,6 +16,8 @@ public interface PopularWordRepository {
 
     List<Word> findAllBy(LocalDateTime target, Pageable pageable);
 
+    List<Word> findByViewCount(Pageable pageable);
+
     Optional<PopularWordMetadata> findBy(Long wordId, LocalDateTime target);
 
     Optional<PopularWordSchedule> findBy(LocalDateTime target);

--- a/src/main/java/com/dnd/spaced/domain/word/domain/repository/QuerydslPopularWordMetadataRepository.java
+++ b/src/main/java/com/dnd/spaced/domain/word/domain/repository/QuerydslPopularWordMetadataRepository.java
@@ -70,6 +70,14 @@ public class QuerydslPopularWordMetadataRepository implements PopularWordReposit
     }
 
     @Override
+    public List<Word> findByViewCount(Pageable pageable) {
+        return queryFactory.selectFrom(word)
+                .orderBy(word.viewCount.desc())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    @Override
     public Optional<PopularWordMetadata> findBy(Long wordId, LocalDateTime target) {
         PopularWordMetadata result = queryFactory.selectFrom(popularWordMetadata)
                 .where(popularWordMetadata.wordId.eq(wordId),


### PR DESCRIPTION
## 📎 관련 Issue 번호
closes #193 

## 📄 작업 내용 요약
기존 API의 findAll 사용으로 인해 많이 찾아본 용어 목록 조회 시 값이 정확하게 반환되지 않는 문제가 있었습니다.  
이를 해결하기 위해 `findByViewCount` 메서드를 추가하여, **viewCount** 를 기준으로 올바르게 데이터를 조회하고,  
해당 데이터를 정상적으로 반환하도록 수정하였습니다.

## 🙋🏻 주의 깊게 확인해야 하는 코드
x

## 📄 개선 사항 OR 참고 사항
x